### PR TITLE
Clarify manifest URI scheme in discovery spec

### DIFF
--- a/SpatialDDS-1.3-full.md
+++ b/SpatialDDS-1.3-full.md
@@ -174,7 +174,15 @@ Together, these profiles give SpatialDDS the flexibility to support robotics, AR
 
 ## **3. Example Manifests**
 
-While SpatialDDS keeps its on-bus messages small and generic, richer details about services, maps, and experiences are provided out-of-band through manifests. A manifest is a lightweight JSON document referenced by a `manifest_uri` in a discovery announce. Manifests let providers describe capabilities, formats, coverage shapes, entry points, and assets without bloating the real-time data stream. The examples here show four common cases: a Visual Positioning Service (VPS) manifest that defines request/response topics and limits, a Mapping Service manifest that specifies tiling scheme and encodings, a Content/Experience manifest that lists anchors, tiles, and media for AR experiences, and an Anchors manifest that enumerates localization anchors with associated assets. Together they illustrate how manifests complement the DDS data plane by carrying descriptive metadata and policy.
+While SpatialDDS keeps its on-bus messages small and generic, richer details about services, maps, and experiences are provided out-of-band through manifests. A manifest is a lightweight JSON document referenced by a `manifest_uri` in a discovery announce. In v1.3 those manifest pointers are canonical `spatialdds://` URIs (e.g., `spatialdds://acme.services/sf/service/vps-main`) that resolve using the rules described in the introduction, guaranteeing stable identifiers even when manifests are hosted on rotating infrastructure. Manifests let providers describe capabilities, formats, coverage shapes, entry points, and assets without bloating the real-time data stream. The examples here show four common cases: a Visual Positioning Service (VPS) manifest that defines request/response topics and limits, a Mapping Service manifest that specifies tiling scheme and encodings, a Content/Experience manifest that lists anchors, tiles, and media for AR experiences, and an Anchors manifest that enumerates localization anchors with associated assets. Together they illustrate how manifests complement the DDS data plane by carrying descriptive metadata and policy.
+
+Example discovery announcements would therefore carry manifest URIs such as:
+
+* `spatial::disco::ServiceAnnounce.manifest_uri = spatialdds://acme.services/sf/service/vps-main`
+* `spatial::disco::ServiceAnnounce.manifest_uri = spatialdds://acme.services/sf/service/mapping-tiles`
+* `spatial::disco::ContentAnnounce.manifest_uri = spatialdds://acme.services/sf/content/market-stroll`
+
+Legacy HTTPS download links can still be advertised inside the manifest body, but the discovery announcements themselves now use the SpatialDDS URI scheme so clients have a consistent, scheme-agnostic handle to resolve.
 
 ### **A) VPS Manifest**
 
@@ -791,6 +799,8 @@ module spatial {
   module disco {
 
     typedef spatial::core::Time Time;
+    // Canonical manifest references use the spatialdds:// URI scheme.
+    typedef string SpatialUri;
 
     enum ServiceKind {
       VPS = 0,
@@ -817,7 +827,7 @@ module spatial {
       sequence<string,16> rx_topics;
       sequence<string,16> tx_topics;
       sequence<KV,32> hints;
-      string manifest_uri;
+      SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this service manifest
       string auth_hint;
       Time stamp;
       uint32 ttl_sec;
@@ -839,7 +849,7 @@ module spatial {
       string summary;
       sequence<string,16> tags;
       string class_id;
-      string manifest_uri;
+      SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this content manifest
       double center_lat; double center_lon; double radius_m;
       Time available_from;
       Time available_until;

--- a/idl/v1.3/discovery.idl
+++ b/idl/v1.3/discovery.idl
@@ -6,6 +6,8 @@ module spatial {
   module disco {
 
     typedef spatial::core::Time Time;
+    // Canonical manifest references use the spatialdds:// URI scheme.
+    typedef string SpatialUri;
 
     enum ServiceKind {
       VPS = 0,
@@ -32,7 +34,7 @@ module spatial {
       sequence<string,16> rx_topics;
       sequence<string,16> tx_topics;
       sequence<KV,32> hints;
-      string manifest_uri;
+      SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this service manifest
       string auth_hint;
       Time stamp;
       uint32 ttl_sec;
@@ -54,7 +56,7 @@ module spatial {
       string summary;
       sequence<string,16> tags;
       string class_id;
-      string manifest_uri;
+      SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this content manifest
       double center_lat; double center_lon; double radius_m;
       Time available_from;
       Time available_until;

--- a/sections/v1.3/03-example-manifests.md
+++ b/sections/v1.3/03-example-manifests.md
@@ -1,6 +1,14 @@
 ## **3. Example Manifests**
 
-While SpatialDDS keeps its on-bus messages small and generic, richer details about services, maps, and experiences are provided out-of-band through manifests. A manifest is a lightweight JSON document referenced by a `manifest_uri` in a discovery announce. Manifests let providers describe capabilities, formats, coverage shapes, entry points, and assets without bloating the real-time data stream. The examples here show four common cases: a Visual Positioning Service (VPS) manifest that defines request/response topics and limits, a Mapping Service manifest that specifies tiling scheme and encodings, a Content/Experience manifest that lists anchors, tiles, and media for AR experiences, and an Anchors manifest that enumerates localization anchors with associated assets. Together they illustrate how manifests complement the DDS data plane by carrying descriptive metadata and policy.
+While SpatialDDS keeps its on-bus messages small and generic, richer details about services, maps, and experiences are provided out-of-band through manifests. A manifest is a lightweight JSON document referenced by a `manifest_uri` in a discovery announce. In v1.3 those manifest pointers are canonical `spatialdds://` URIs (e.g., `spatialdds://acme.services/sf/service/vps-main`) that resolve using the rules described in the introduction, guaranteeing stable identifiers even when manifests are hosted on rotating infrastructure. Manifests let providers describe capabilities, formats, coverage shapes, entry points, and assets without bloating the real-time data stream. The examples here show four common cases: a Visual Positioning Service (VPS) manifest that defines request/response topics and limits, a Mapping Service manifest that specifies tiling scheme and encodings, a Content/Experience manifest that lists anchors, tiles, and media for AR experiences, and an Anchors manifest that enumerates localization anchors with associated assets. Together they illustrate how manifests complement the DDS data plane by carrying descriptive metadata and policy.
+
+Example discovery announcements would therefore carry manifest URIs such as:
+
+* `spatial::disco::ServiceAnnounce.manifest_uri = spatialdds://acme.services/sf/service/vps-main`
+* `spatial::disco::ServiceAnnounce.manifest_uri = spatialdds://acme.services/sf/service/mapping-tiles`
+* `spatial::disco::ContentAnnounce.manifest_uri = spatialdds://acme.services/sf/content/market-stroll`
+
+Legacy HTTPS download links can still be advertised inside the manifest body, but the discovery announcements themselves now use the SpatialDDS URI scheme so clients have a consistent, scheme-agnostic handle to resolve.
 
 ### **A) VPS Manifest**
 


### PR DESCRIPTION
## Summary
- add a SpatialUri typedef in the discovery IDL and note that manifest references must be `spatialdds://` URIs
- update the example manifest prose to illustrate discovery announcements using canonical SpatialDDS URIs
- rebuild the aggregated 1.3 specification so it reflects the IDL and prose changes

## Testing
- ./scripts/build-spec.sh 1.3

------
https://chatgpt.com/codex/tasks/task_e_68d22febfb90832c9253f6d57a59522b