### PR TITLE
Fix full spec ordering and appendix labels

### DIFF
--- a/SpatialDDS-1.2-full.md
+++ b/SpatialDDS-1.2-full.md
@@ -18,9 +18,9 @@
 7. [Glossary of Acronyms](sections/v1.2/glossary.md)
 8. [References](sections/v1.2/references.md)
 9. Appendices
-   - [Appendix A: Core Profile 1.0](sections/v1.2/appendix-a.md)
-   - [Appendix B: Discovery Profile 1.0](sections/v1.2/appendix-b.md)
-   - [Appendix C: Anchor Registry Profile 1.0](sections/v1.2/appendix-c.md)
+   - [Appendix A: Core Profile](sections/v1.2/appendix-a.md)
+   - [Appendix B: Discovery Profile](sections/v1.2/appendix-b.md)
+   - [Appendix C: Anchor Registry Profile](sections/v1.2/appendix-c.md)
    - [Appendix D: Extension Profiles](sections/v1.2/appendix-d.md)
    - [Appendix E: Provisional Extension Examples](sections/v1.2/appendix-e.md)
 
@@ -570,7 +570,7 @@ We invite implementers, researchers, and standards bodies to explore SpatialDDS,
 \[12\] Google Research. *ARCore Geospatial API & Visual Positioning Service.* Developer Documentation. Available: [https://developers.google.com/ar](https://developers.google.com/ar)
 
 
-## **Appendix A: Core Profile 1.0**
+## **Appendix A: Core Profile**
 
 *The Core profile defines the fundamental data structures for SpatialDDS. It includes pose graphs, 3D geometry tiles, anchors, transforms, and generic blob transport. This is the minimal interoperable baseline for exchanging world models across devices and services.*
 
@@ -719,7 +719,7 @@ module spatial {
 
 ```
 
-## **Appendix B: Discovery Profile 1.0**
+## **Appendix B: Discovery Profile**
 
 *The Discovery profile defines the lightweight announce messages and manifests that allow services, coverage areas, and spatial content or experiences to be discovered at runtime. It enables SpatialDDS deployments to remain decentralized while still providing structured service discovery.*
 
@@ -793,7 +793,7 @@ module spatial {
 
 ```
 
-## **Appendix C: Anchor Registry Profile 1.0**
+## **Appendix C: Anchor Registry Profile**
 
 *The Anchors profile defines durable GeoAnchors and the Anchor Registry. Anchors act as persistent world-locked reference points, while the registry makes them discoverable and maintainable across sessions, devices, and services.*
 
@@ -861,7 +861,7 @@ module spatial {
 
 *These extensions provide domain-specific capabilities beyond the Core profile. The VIO profile carries raw and fused IMU/magnetometer samples. The SLAM Frontend profile adds features and keyframes for SLAM and SfM pipelines. The Semantics profile allows 2D and 3D object detections to be exchanged for AR, robotics, and analytics use cases. The AR+Geo profile adds GeoPose, frame transforms, and geo-anchoring structures, which allow clients to align local coordinate systems with global reference frames and support persistent AR content.*
 
-### **VIO / Inertial Extension 1.0**
+### **VIO / Inertial Extension**
 
 *Raw IMU/mag samples, 9-DoF bundles, and fused state outputs.*
 
@@ -950,7 +950,7 @@ module spatial {
 
 ```
 
-### **SLAM Frontend Extension 1.0**
+### **SLAM Frontend Extension**
 
 *Per-keyframe features, matches, landmarks, tracks, and camera calibration.*
 
@@ -1044,7 +1044,7 @@ module spatial {
 
 ```
 
-### **Semantics / Perception Extension 1.0**
+### **Semantics / Perception Extension**
 
 *2D detections tied to keyframes; 3D oriented boxes in world frames (optionally tiled).*
 
@@ -1122,7 +1122,7 @@ module spatial {
 
 ```
 
-### **AR + Geo Extension 1.0**
+### **AR + Geo Extension**
 
 *Geo-fixed nodes for easy consumption by AR clients & multi-agent alignment.*
 

--- a/SpatialDDS-1.2.md
+++ b/SpatialDDS-1.2.md
@@ -18,8 +18,8 @@
 7. [Glossary of Acronyms](sections/v1.2/glossary.md)
 8. [References](sections/v1.2/references.md)
 9. Appendices
-   - [Appendix A: Core Profile 1.0](sections/v1.2/appendix-a.md)
-   - [Appendix B: Discovery Profile 1.0](sections/v1.2/appendix-b.md)
-   - [Appendix C: Anchor Registry Profile 1.0](sections/v1.2/appendix-c.md)
+   - [Appendix A: Core Profile](sections/v1.2/appendix-a.md)
+   - [Appendix B: Discovery Profile](sections/v1.2/appendix-b.md)
+   - [Appendix C: Anchor Registry Profile](sections/v1.2/appendix-c.md)
    - [Appendix D: Extension Profiles](sections/v1.2/appendix-d.md)
    - [Appendix E: Provisional Extension Examples](sections/v1.2/appendix-e.md)

--- a/SpatialDDS-1.3.md
+++ b/SpatialDDS-1.3.md
@@ -27,8 +27,8 @@
 8. [Glossary of Acronyms](sections/v1.3/glossary.md)
 9. [References](sections/v1.3/references.md)
 10. Appendices
-    - [Appendix A: Core Profile 1.0](sections/v1.3/appendix-a.md)
-    - [Appendix B: Discovery Profile 1.0](sections/v1.3/appendix-b.md)
-    - [Appendix C: Anchor Registry Profile 1.0](sections/v1.3/appendix-c.md)
+    - [Appendix A: Core Profile](sections/v1.3/appendix-a.md)
+    - [Appendix B: Discovery Profile](sections/v1.3/appendix-b.md)
+    - [Appendix C: Anchor Registry Profile](sections/v1.3/appendix-c.md)
     - [Appendix D: Extension Profiles](sections/v1.3/appendix-d.md)
     - [Appendix E: Provisional Extension Examples](sections/v1.3/appendix-e.md)

--- a/sections/v1.2/appendix-a.md
+++ b/sections/v1.2/appendix-a.md
@@ -1,4 +1,4 @@
-## **Appendix A: Core Profile 1.0**
+## **Appendix A: Core Profile**
 
 *The Core profile defines the fundamental data structures for SpatialDDS. It includes pose graphs, 3D geometry tiles, anchors, transforms, and generic blob transport. This is the minimal interoperable baseline for exchanging world models across devices and services.*
 

--- a/sections/v1.2/appendix-b.md
+++ b/sections/v1.2/appendix-b.md
@@ -1,4 +1,4 @@
-## **Appendix B: Discovery Profile 1.0**
+## **Appendix B: Discovery Profile**
 
 *The Discovery profile defines the lightweight announce messages and manifests that allow services, coverage areas, and spatial content or experiences to be discovered at runtime. It enables SpatialDDS deployments to remain decentralized while still providing structured service discovery.*
 

--- a/sections/v1.2/appendix-c.md
+++ b/sections/v1.2/appendix-c.md
@@ -1,4 +1,4 @@
-## **Appendix C: Anchor Registry Profile 1.0**
+## **Appendix C: Anchor Registry Profile**
 
 *The Anchors profile defines durable GeoAnchors and the Anchor Registry. Anchors act as persistent world-locked reference points, while the registry makes them discoverable and maintainable across sessions, devices, and services.*
 

--- a/sections/v1.2/appendix-d.md
+++ b/sections/v1.2/appendix-d.md
@@ -2,7 +2,7 @@
 
 *These extensions provide domain-specific capabilities beyond the Core profile. The VIO profile carries raw and fused IMU/magnetometer samples. The SLAM Frontend profile adds features and keyframes for SLAM and SfM pipelines. The Semantics profile allows 2D and 3D object detections to be exchanged for AR, robotics, and analytics use cases. The AR+Geo profile adds GeoPose, frame transforms, and geo-anchoring structures, which allow clients to align local coordinate systems with global reference frames and support persistent AR content.*
 
-### **VIO / Inertial Extension 1.0**
+### **VIO / Inertial Extension**
 
 *Raw IMU/mag samples, 9-DoF bundles, and fused state outputs.*
 
@@ -10,7 +10,7 @@
 {{include:idl/v1.2/vio.idl}}
 ```
 
-### **SLAM Frontend Extension 1.0**
+### **SLAM Frontend Extension**
 
 *Per-keyframe features, matches, landmarks, tracks, and camera calibration.*
 
@@ -18,7 +18,7 @@
 {{include:idl/v1.2/slam_frontend.idl}}
 ```
 
-### **Semantics / Perception Extension 1.0**
+### **Semantics / Perception Extension**
 
 *2D detections tied to keyframes; 3D oriented boxes in world frames (optionally tiled).*
 
@@ -26,7 +26,7 @@
 {{include:idl/v1.2/semantics.idl}}
 ```
 
-### **AR + Geo Extension 1.0**
+### **AR + Geo Extension**
 
 *Geo-fixed nodes for easy consumption by AR clients & multi-agent alignment.*
 

--- a/sections/v1.3/appendix-a.md
+++ b/sections/v1.3/appendix-a.md
@@ -1,4 +1,4 @@
-## **Appendix A: Core Profile 1.0**
+## **Appendix A: Core Profile**
 
 *The Core profile defines the fundamental data structures for SpatialDDS. It includes pose graphs, 3D geometry tiles, anchors, transforms, and generic blob transport. This is the minimal interoperable baseline for exchanging world models across devices and services.*
 

--- a/sections/v1.3/appendix-b.md
+++ b/sections/v1.3/appendix-b.md
@@ -1,4 +1,4 @@
-## **Appendix B: Discovery Profile 1.0**
+## **Appendix B: Discovery Profile**
 
 *The Discovery profile defines the lightweight announce messages and manifests that allow services, coverage areas, and spatial content or experiences to be discovered at runtime. It enables SpatialDDS deployments to remain decentralized while still providing structured service discovery.*
 

--- a/sections/v1.3/appendix-c.md
+++ b/sections/v1.3/appendix-c.md
@@ -1,4 +1,4 @@
-## **Appendix C: Anchor Registry Profile 1.0**
+## **Appendix C: Anchor Registry Profile**
 
 *The Anchors profile defines durable GeoAnchors and the Anchor Registry. Anchors act as persistent world-locked reference points, while the registry makes them discoverable and maintainable across sessions, devices, and services.*
 

--- a/sections/v1.3/appendix-d.md
+++ b/sections/v1.3/appendix-d.md
@@ -2,7 +2,7 @@
 
 *These extensions provide domain-specific capabilities beyond the Core profile. The VIO profile carries raw and fused IMU/magnetometer samples. The SLAM Frontend profile adds features and keyframes for SLAM and SfM pipelines. The Semantics profile allows 2D and 3D object detections to be exchanged for AR, robotics, and analytics use cases. The AR+Geo profile adds GeoPose, frame transforms, and geo-anchoring structures, which allow clients to align local coordinate systems with global reference frames and support persistent AR content.*
 
-### **VIO / Inertial Extension 1.0**
+### **VIO / Inertial Extension**
 
 *Raw IMU/mag samples, 9-DoF bundles, and fused state outputs.*
 
@@ -10,7 +10,7 @@
 {{include:idl/v1.3/vio.idl}}
 ```
 
-### **SLAM Frontend Extension 1.0**
+### **SLAM Frontend Extension**
 
 *Per-keyframe features, matches, landmarks, tracks, and camera calibration.*
 
@@ -18,7 +18,7 @@
 {{include:idl/v1.3/slam_frontend.idl}}
 ```
 
-### **Semantics / Perception Extension 1.0**
+### **Semantics / Perception Extension**
 
 *2D detections tied to keyframes; 3D oriented boxes in world frames (optionally tiled).*
 
@@ -26,7 +26,7 @@
 {{include:idl/v1.3/semantics.idl}}
 ```
 
-### **AR + Geo Extension 1.0**
+### **AR + Geo Extension**
 
 *Geo-fixed nodes for easy consumption by AR clients & multi-agent alignment.*
 


### PR DESCRIPTION
## Summary
- update the build script to expand sections in the order listed in each version's table of contents
- drop the "1.0" suffix from appendix profile headings in the v1.2 and v1.3 sources and tables of contents
- regenerate the full specifications so the numbering flows correctly and appendix titles match the sources

## Testing
- ./scripts/build-spec.sh 1.3
- ./scripts/build-spec.sh 1.2

------
https://chatgpt.com/codex/tasks/task_e_68d3611373ec832cb3d4ffbfddbe8b78