### PR TITLE
Add contributing guide with explicit patent grant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to the SpatialDDS Specification
+
+Thank you for your interest in helping to improve SpatialDDS. We welcome fixes, clarifications, and new material that advance the specification and its supporting documents.
+
+## How to Propose Changes
+
+1. **Discuss major ideas first.** Open an issue to describe significant additions or revisions before submitting a patch.
+2. **Keep changes focused.** Smaller, well scoped contributions are easier to review and merge.
+3. **Follow the style of nearby text.** Preserve existing terminology, section structure, and formatting conventions when editing specification files.
+4. **Document your rationale.** Explain why the change is needed and how it improves the project when you open a pull request.
+
+## Licensing of Contributions
+
+By submitting a contribution, you agree that your work will be licensed under the Creative Commons Attribution 4.0 International License, which is the license that governs this repository.
+
+You confirm that you are legally entitled to submit the contribution and to grant the rights described here, and that your submission does not infringe on the rights of any third party.
+
+## Patent Grant
+
+To the fullest extent permitted by applicable law, you hereby grant to the SpatialDDS project maintainers, contributors, and all recipients of your contribution a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contribution and derivative works of your contribution.
+
+If you initiate or participate in a patent claim against any entity alleging that the SpatialDDS specification, this repository, or any contribution to it infringes your patent rights, then your patent license to the project shall terminate as of the date that such claim is filed.
+
+## Contribution Process Checklist
+
+Before submitting, please:
+
+- Ensure your changes build and render correctly, when applicable.
+- Update any relevant references or cross-links within the documentation.
+- Provide clear commit messages that describe the purpose of each change.
+
+We appreciate your help in making SpatialDDS better for everyone.


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide to outline the preferred workflow
- document licensing expectations for incoming contributions
- include an explicit patent grant covering contributed material

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d36ca6fcd0832c8fb5c5c38d435e16