### PR TITLE
Add MkDocs site for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,54 @@
+name: Deploy MkDocs site
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Assemble specification sources
+        run: |
+          ./scripts/build-spec.sh 1.2
+          ./scripts/build-spec.sh 1.3
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SpatialDDS is a concept protocol for real-world spatial computing that defines a
 
 It's released to spark discussion—explore the spec, experiment, and join the conversation through issues or pull requests to help shape future iterations.
 
-This repository hosts the published 1.2 specification alongside a work-in-progress 1.3 draft. See the [CHANGELOG](CHANGELOG.md) for version history.
+This repository hosts the published 1.2 specification alongside a work-in-progress 1.3 draft. See the [CHANGELOG](CHANGELOG.md) for version history. The rendered documentation is published at [openarcloud.github.io/SpatialDDS-spec](https://openarcloud.github.io/SpatialDDS-spec/).
 
 ## Repository structure
 
@@ -25,6 +25,19 @@ All IDL files in `idl/v*/` and manifest examples in `manifests/v*/` are treated 
 ```
 
 The script injects the referenced IDL and manifest sources and writes `SpatialDDS-<version>-full.md` to the repository root, providing a convenient reference to the complete spec.
+
+## Documentation site
+
+The documentation site is generated with [MkDocs](https://www.mkdocs.org/). To preview it locally:
+
+```bash
+pip install -r requirements.txt
+./scripts/build-spec.sh 1.2
+./scripts/build-spec.sh 1.3
+mkdocs serve
+```
+
+The GitHub Actions workflow in `.github/workflows/deploy-docs.yml` rebuilds the site and deploys it to GitHub Pages whenever changes land on `main`.
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# SpatialDDS Specification Portal
+
+Welcome to the SpatialDDS specification site. SpatialDDS defines an open protocol
+for exchanging spatial data, digital twins, and AI-generated world models.
+
+Use the navigation to explore the latest specification, learn about the
+underlying profiles, and review supporting appendices. Each release of the
+specification is published in full so that you can search, link, and reference it
+like a traditional research document.
+
+## Getting started
+
+- Read the [SpatialDDS v1.3 Specification](specification-v1-3.md) for the latest
+  draft, including appendices and glossary material.
+- Consult the [SpatialDDS v1.2 Specification](specification-v1-2.md) for the
+  previous release.
+- Visit the SpatialDDS [IDL](../idl/) and [manifest](../manifests/) directories
+  in this repository for additional example assets.
+
+## Local development
+
+You can preview the site locally by installing the MkDocs dependencies and
+running the development server:
+
+```bash
+pip install -r requirements.txt
+./scripts/build-spec.sh 1.2
+./scripts/build-spec.sh 1.3
+mkdocs serve
+```
+
+MkDocs will rebuild automatically as you edit the Markdown sources.

--- a/docs/specification-v1-2.md
+++ b/docs/specification-v1-2.md
@@ -1,0 +1,6 @@
+---
+title: SpatialDDS Specification v1.2
+description: Full text of the SpatialDDS specification version 1.2.
+---
+
+--8<-- "../SpatialDDS-1.2-full.md"

--- a/docs/specification-v1-3.md
+++ b/docs/specification-v1-3.md
@@ -1,0 +1,6 @@
+---
+title: SpatialDDS Specification v1.3
+description: Full text of the SpatialDDS specification version 1.3 (draft).
+---
+
+--8<-- "../SpatialDDS-1.3-full.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: SpatialDDS Specification
+site_description: SpatialDDS protocol specification and appendices.
+site_url: https://openarcloud.github.io/SpatialDDS-spec/
+repo_url: https://github.com/OpenARCloud/SpatialDDS-spec
+repo_name: OpenARCloud/SpatialDDS-spec
+
+nav:
+  - Home: index.md
+  - Specifications:
+      - "Version 1.3 (Draft)": specification-v1-3.md
+      - "Version 1.2": specification-v1-2.md
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.tabs
+    - navigation.top
+    - toc.integrate
+  palette:
+    scheme: default
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/OpenARCloud/SpatialDDS-spec
+      name: SpatialDDS on GitHub
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.5
+mkdocs-material>=9.5


### PR DESCRIPTION
## Summary
- add a MkDocs configuration and documentation pages that render the SpatialDDS specs
- create a GitHub Actions workflow to build and deploy the site to GitHub Pages
- document how to work with the site locally and where the hosted version lives

## Testing
- pip install -r requirements.txt *(fails: network proxy prevents downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d37d1b3c00832ca0ae0536b722753c