### PR TITLE
Fix specification includes and external links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,9 @@ like a traditional research document.
   draft, including appendices and glossary material.
 - Consult the [SpatialDDS v1.2 Specification](specification-v1-2.md) for the
   previous release.
-- Visit the SpatialDDS [IDL](../idl/) and [manifest](../manifests/) directories
-  in this repository for additional example assets.
+- Visit the SpatialDDS [IDL](https://github.com/OpenARCloud/SpatialDDS-spec/tree/main/idl)
+  and [manifest](https://github.com/OpenARCloud/SpatialDDS-spec/tree/main/manifests)
+  directories in this repository for additional example assets.
 
 ## Local development
 

--- a/docs/specification-v1-2.md
+++ b/docs/specification-v1-2.md
@@ -3,4 +3,4 @@ title: SpatialDDS Specification v1.2
 description: Full text of the SpatialDDS specification version 1.2.
 ---
 
---8<-- "../SpatialDDS-1.2-full.md"
+--8<-- "SpatialDDS-1.2-full.md"

--- a/docs/specification-v1-3.md
+++ b/docs/specification-v1-3.md
@@ -3,4 +3,4 @@ title: SpatialDDS Specification v1.3
 description: Full text of the SpatialDDS specification version 1.3 (draft).
 ---
 
---8<-- "../SpatialDDS-1.3-full.md"
+--8<-- "SpatialDDS-1.3-full.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,11 @@ markdown_extensions:
       permalink: true
   - pymdownx.highlight
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      base_path:
+        - docs
+        - .
+      check_paths: true
   - pymdownx.superfences
 
 plugins:


### PR DESCRIPTION
## Summary
- allow pymdownx snippet includes to read full specification files from the repo root
- update the spec pages to reference the generated full documents using the new path
- point the IDL and manifest links on the landing page to their GitHub locations so they no longer 404

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails: ProxyError prevents downloading mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68d383b28e34832c881ac460a16b8413