### PR TITLE
Introduce coverage elements and transforms for flexible frames

### DIFF
--- a/idl/v1.3/core.idl
+++ b/idl/v1.3/core.idl
@@ -15,6 +15,11 @@ module spatial {
       double q[4];    // quaternion (x,y,z,w) in GeoPose order
     };
 
+    struct Aabb3 {
+      double min_xyz[3];
+      double max_xyz[3];
+    };
+
     @appendable struct TileKey {
       @key uint32 x;     // tile coordinate (quadtree/3D grid)
       @key uint32 y;

--- a/idl/v1.3/discovery.idl
+++ b/idl/v1.3/discovery.idl
@@ -6,6 +6,7 @@ module spatial {
   module disco {
 
     typedef spatial::core::Time Time;
+    typedef spatial::core::Aabb3 Aabb3;
     // Canonical manifest references use the spatialdds:// URI scheme.
     typedef string SpatialUri;
 
@@ -25,10 +26,21 @@ module spatial {
       string value;
     };
 
-    @appendable struct CoverageVolume {
-      string frame;             // coordinate frame for this volume (defaults to "earth-fixed" when empty)
-      double min_xyz[3];        // axis-aligned min corner in the declared frame (meters for linear frames, lon/lat/alt for earth-fixed)
-      double max_xyz[3];        // axis-aligned max corner in the declared frame
+    @appendable struct CoverageElement {
+      string type;              // "bbox" | "volume"
+      string frame;             // coordinate frame for this element (e.g., "earth-fixed", "map")
+      string crs;               // optional CRS identifier for earth-fixed frames (e.g., EPSG code)
+      double bbox[4];           // [min_lon, min_lat, max_lon, max_lat] when type == "bbox"
+      Aabb3 aabb;               // axis-aligned bounds when type == "volume"
+    };
+
+    @appendable struct Transform {
+      string from;              // source frame (e.g., "map")
+      string to;                // target frame (e.g., "earth-fixed")
+      string stamp;             // ISO-8601 timestamp for this transform
+      uint32 valid_for_s;       // validity horizon in seconds
+      double t_m[3];            // translation in meters
+      double q_wxyz[4];         // quaternion (w,x,y,z)
     };
 
     @appendable struct ServiceAnnounce {
@@ -40,6 +52,8 @@ module spatial {
       sequence<string,16> rx_topics;
       sequence<string,16> tx_topics;
       sequence<KV,32> hints;
+      sequence<CoverageElement,16> coverage;
+      sequence<Transform,8> transforms;
       SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this service manifest
       string auth_hint;
       Time stamp;
@@ -48,17 +62,15 @@ module spatial {
 
     @appendable struct CoverageHint {
       @key string service_id;
-      sequence<string,64> geohash;
-      double bbox[4];           // [min_lon, min_lat, max_lon, max_lat]
-      double center_lat; double center_lon; double radius_m;
-      sequence<CoverageVolume,8> volumes;  // optional precise 3D volumes covered by this service
+      sequence<CoverageElement,16> coverage;
+      sequence<Transform,8> transforms;
       Time stamp;
       uint32 ttl_sec;
     };
 
     @appendable struct CoverageQuery {
       @key string query_id;
-      CoverageVolume volume;    // requested 3D volume of interest
+      sequence<CoverageElement,4> coverage;  // requested regions of interest
       Time stamp;
       uint32 ttl_sec;
     };
@@ -71,7 +83,8 @@ module spatial {
       sequence<string,16> tags;
       string class_id;
       SpatialUri manifest_uri;  // MUST be a spatialdds:// URI for this content manifest
-      double center_lat; double center_lon; double radius_m;
+      sequence<CoverageElement,16> coverage;
+      sequence<Transform,8> transforms;
       Time available_from;
       Time available_until;
       Time stamp;

--- a/manifests/v1.3/anchors_manifest.json
+++ b/manifests/v1.3/anchors_manifest.json
@@ -3,21 +3,60 @@
   "zone_id": "knossos:palace",
   "zone_title": "Knossos Palace Archaeological Site",
   "coverage": {
-    "geohash": ["sv8wkf", "sv8wkg"],
-    "bbox": [
-      25.1608,
-      35.2965,
-      25.1665,
-      35.3002
+    "geohash": [
+      "sv8wkf",
+      "sv8wkg"
     ],
-    "volumes": [
+    "elements": [
       {
+        "type": "volume",
+        "frame": "gallery-local",
+        "aabb": {
+          "min_xyz": [
+            -15.0,
+            -20.0,
+            -2.0
+          ],
+          "max_xyz": [
+            15.0,
+            20.0,
+            6.0
+          ]
+        }
+      },
+      {
+        "type": "bbox",
         "frame": "earth-fixed",
-        "min_xyz": [25.1600, 35.2960, 100.0],
-        "max_xyz": [25.1670, 35.3010, 130.0]
+        "bbox": [
+          25.1608,
+          35.2965,
+          25.1665,
+          35.3002
+        ]
       }
     ]
   },
+  "transforms": [
+    {
+      "from": "gallery-local",
+      "to": "earth-fixed",
+      "stamp": "2025-02-18T08:00:00Z",
+      "valid_for_s": 600,
+      "pose": {
+        "t_m": [
+          25.1635,
+          35.298,
+          112.0
+        ],
+        "q_wxyz": [
+          0.9659,
+          0.0,
+          0.2588,
+          0.0
+        ]
+      }
+    }
+  ],
   "anchors": [
     {
       "anchor_id": "square:statue-east",

--- a/manifests/v1.3/content_experience_manifest.json
+++ b/manifests/v1.3/content_experience_manifest.json
@@ -1,39 +1,116 @@
 {
   "content_id": "xp:sculpture-walk:met-foyer",
   "version": "1.0.2",
-  "provider": { "id": "svc:content:museum-inc", "org": "Museum Inc." },
+  "provider": {
+    "id": "svc:content:museum-inc",
+    "org": "Museum Inc."
+  },
   "title": "AR Sculpture Walk",
   "summary": "Guided AR overlays for five sculptures in the main foyer.",
-  "tags": ["ar", "museum", "tour"],
-  "profiles_required": ["Core", "AR+Geo"],
+  "tags": [
+    "ar",
+    "museum",
+    "tour"
+  ],
+  "profiles_required": [
+    "Core",
+    "AR+Geo"
+  ],
   "availability": {
     "from": "2025-09-01T09:00:00Z",
     "until": "2025-12-31T23:59:59Z",
     "local_tz": "America/New_York"
   },
   "coverage": {
-    "geohash": ["dr5ru9","dr5rua"],
+    "geohash": [
+      "dr5ru9",
+      "dr5rua"
+    ],
     "polygon_uri": "https://cdn.museum.example/foyer_poly.geojson",
-    "volumes": [
+    "elements": [
       {
+        "type": "bbox",
         "frame": "earth-fixed",
-        "min_xyz": [-73.9635, 40.7793, 20.0],
-        "max_xyz": [-73.9631, 40.7796, 35.0]
+        "bbox": [
+          -73.9635,
+          40.7793,
+          -73.9631,
+          40.7796
+        ]
+      },
+      {
+        "type": "volume",
+        "frame": "foyer-local",
+        "aabb": {
+          "min_xyz": [
+            -8.0,
+            -12.0,
+            0.0
+          ],
+          "max_xyz": [
+            8.0,
+            12.0,
+            5.0
+          ]
+        }
       }
     ]
   },
+  "transforms": [
+    {
+      "from": "foyer-local",
+      "to": "earth-fixed",
+      "stamp": "2025-09-01T09:00:00Z",
+      "valid_for_s": 3600,
+      "pose": {
+        "t_m": [
+          -73.9633,
+          40.7794,
+          25.5
+        ],
+        "q_wxyz": [
+          0.9239,
+          0.0,
+          0.3827,
+          0.0
+        ]
+      }
+    }
+  ],
   "entrypoints": {
     "anchors": [
-      { "anchor_id": "anchor/met-foyer/north-plinth", "hint": "Start here" },
-      { "anchor_id": "anchor/met-foyer/central", "hint": "Checkpoint 2" }
+      {
+        "anchor_id": "anchor/met-foyer/north-plinth",
+        "hint": "Start here"
+      },
+      {
+        "anchor_id": "anchor/met-foyer/central",
+        "hint": "Checkpoint 2"
+      }
     ]
   },
   "runtime_topics": {
-    "subscribe": ["geo.tf", "geo.anchor", "geom.tile.meta", "geom.tile.patch"],
-    "optional": ["semantics.det.3d.set"]
+    "subscribe": [
+      "geo.tf",
+      "geo.anchor",
+      "geom.tile.meta",
+      "geom.tile.patch"
+    ],
+    "optional": [
+      "semantics.det.3d.set"
+    ]
   },
   "assets": [
-    { "type": "image", "role": "poster", "uri": "https://cdn.museum.example/img/poster.jpg" },
-    { "type": "audio", "role": "narration", "uri": "https://cdn.museum.example/audio/room_intro.mp3", "lang": "en" }
+    {
+      "type": "image",
+      "role": "poster",
+      "uri": "https://cdn.museum.example/img/poster.jpg"
+    },
+    {
+      "type": "audio",
+      "role": "narration",
+      "uri": "https://cdn.museum.example/audio/room_intro.mp3",
+      "lang": "en"
+    }
   ]
 }

--- a/manifests/v1.3/mapping_service_manifest.json
+++ b/manifests/v1.3/mapping_service_manifest.json
@@ -1,29 +1,68 @@
 {
   "service_id": "svc:mapping:acme/sf-downtown",
   "version": "1.0.0",
-  "provider": { "id": "acme-maps", "org": "Acme Maps Inc." },
+  "provider": {
+    "id": "acme-maps",
+    "org": "Acme Maps Inc."
+  },
   "title": "Acme Downtown Map Service",
   "summary": "Tiled 3D meshes for SF downtown area",
-  "profiles": ["Core"],
+  "profiles": [
+    "Core"
+  ],
   "topics": {
     "meta": "geom.tile.meta",
     "patch": "geom.tile.patch",
     "blob": "geom.tile.blob"
   },
   "tile_scheme": "quadtree",
-  "encodings": ["glTF+Draco", "LASzip"],
-  "lod_range": [12, 18],
+  "encodings": [
+    "glTF+Draco",
+    "LASzip"
+  ],
+  "lod_range": [
+    12,
+    18
+  ],
   "coverage": {
-    "geohash": ["9q8y","9q8z"],
+    "geohash": [
+      "9q8y",
+      "9q8z"
+    ],
     "polygon_uri": "https://cdn.acme.example/downtown_poly.geojson",
-    "volumes": [
+    "elements": [
       {
+        "type": "bbox",
         "frame": "earth-fixed",
-        "min_xyz": [-122.4195, 37.7925, -10.0],
-        "max_xyz": [-122.4115, 37.7990, 250.0]
+        "bbox": [
+          -122.4195,
+          37.7925,
+          -122.4115,
+          37.799
+        ]
+      },
+      {
+        "type": "volume",
+        "frame": "earth-fixed",
+        "aabb": {
+          "min_xyz": [
+            -122.4195,
+            37.7925,
+            -10.0
+          ],
+          "max_xyz": [
+            -122.4115,
+            37.799,
+            250.0
+          ]
+        }
       }
     ]
   },
-  "auth": { "scheme": "none" },
-  "terms": { "license": "CC-BY-4.0" }
+  "auth": {
+    "scheme": "none"
+  },
+  "terms": {
+    "license": "CC-BY-4.0"
+  }
 }

--- a/manifests/v1.3/vps_manifest.json
+++ b/manifests/v1.3/vps_manifest.json
@@ -1,6 +1,10 @@
 {
   "service_id": "svc:vps:acme/sf-downtown",
-  "profiles": ["Core", "SLAM Frontend", "AR+Geo"],
+  "profiles": [
+    "Core",
+    "SLAM Frontend",
+    "AR+Geo"
+  ],
   "request": {
     "features_topic": "feat.keyframe",
     "image_blob_role": "image/jpeg",
@@ -10,22 +14,46 @@
     "rich": "pg.nodegeo",
     "minimal": "geo.fix"
   },
-  "limits": { "max_fps": 10, "max_image_px": 1920 },
-  "auth": { "scheme": "oauth2", "issuer": "https://auth.acme.com" },
+  "limits": {
+    "max_fps": 10,
+    "max_image_px": 1920
+  },
+  "auth": {
+    "scheme": "oauth2",
+    "issuer": "https://auth.acme.com"
+  },
   "coverage": {
-    "frame": "ship-fixed",
-    "geohash": ["9q8y", "9q8z"],
-    "bbox": [
-      -122.4186,
-      37.7931,
-      -122.4123,
-      37.7982
+    "geohash": [
+      "9q8y",
+      "9q8z"
     ],
-    "volumes": [
+    "elements": [
       {
+        "type": "bbox",
+        "frame": "earth-fixed",
+        "crs": "EPSG:4979",
+        "bbox": [
+          -122.4186,
+          37.7931,
+          -122.4123,
+          37.7982
+        ]
+      },
+      {
+        "type": "volume",
         "frame": "ship-fixed",
-        "min_xyz": [-25.0, -30.0, -5.0],
-        "max_xyz": [25.0, 30.0, 20.0]
+        "aabb": {
+          "min_xyz": [
+            -25.0,
+            -30.0,
+            -5.0
+          ],
+          "max_xyz": [
+            25.0,
+            30.0,
+            20.0
+          ]
+        }
       }
     ]
   },
@@ -34,19 +62,20 @@
       "from": "ship-fixed",
       "to": "earth-fixed",
       "stamp": "2025-05-01T12:00:00Z",
-      "pose": {
-        "t_m": [-2650.4, 15.2, 8.6],
-        "q_wxyz": [0.9239, 0.0, 0.3827, 0.0]
-      },
       "valid_for_s": 5,
-      "covariance": [
-        0.25, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.25, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.25, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 1e-6, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 1e-6, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 1e-6
-      ]
+      "pose": {
+        "t_m": [
+          -2650.4,
+          15.2,
+          8.6
+        ],
+        "q_wxyz": [
+          0.9239,
+          0.0,
+          0.3827,
+          0.0
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- document the new coverage.elements model and show mixed local/earth-fixed examples in the v1.3 spec manifests
- add reusable Aabb3, CoverageElement, and Transform structures and wire them into discovery announces
- refresh the reference JSON manifests to match the updated coverage and transform semantics

## Testing
- not run (spec-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5f7ae1b24832c863056409a4b78d8