### PR TITLE
Clarify coverage and transform usage in manifests and IDL

### DIFF
--- a/idl/v1.3/discovery.idl
+++ b/idl/v1.3/discovery.idl
@@ -26,21 +26,24 @@ module spatial {
       string value;
     };
 
+    // CoverageElement: if frame == "earth-fixed", bbox is [west,south,east,north] in degrees (EPSG:4326/4979);
+    // otherwise local meters; volume is AABB in meters.
     @appendable struct CoverageElement {
       string type;              // "bbox" | "volume"
       string frame;             // coordinate frame for this element (e.g., "earth-fixed", "map")
       string crs;               // optional CRS identifier for earth-fixed frames (e.g., EPSG code)
-      double bbox[4];           // [min_lon, min_lat, max_lon, max_lat] when type == "bbox"
+      double bbox[4];           // [west, south, east, north] when type == "bbox"
       Aabb3 aabb;               // axis-aligned bounds when type == "volume"
     };
 
+    // Quaternion follows GeoPose: unit [w,x,y,z]; pose maps FROM 'from' TO 'to'
     @appendable struct Transform {
       string from;              // source frame (e.g., "map")
       string to;                // target frame (e.g., "earth-fixed")
       string stamp;             // ISO-8601 timestamp for this transform
       uint32 valid_for_s;       // validity horizon in seconds
-      double t_m[3];            // translation in meters
-      double q_wxyz[4];         // quaternion (w,x,y,z)
+      double t_m[3];            // meters in 'from' frame
+      double q_wxyz[4];         // GeoPose order [w,x,y,z]
     };
 
     @appendable struct ServiceAnnounce {

--- a/manifests/v1.3/anchors_manifest.json
+++ b/manifests/v1.3/anchors_manifest.json
@@ -3,6 +3,7 @@
   "zone_id": "knossos:palace",
   "zone_title": "Knossos Palace Archaeological Site",
   "coverage": {
+    "$comment": "If multiple coverage elements are present, they must bound the same resource. geohash (if used) is always earth-fixed.",
     "geohash": [
       "sv8wkf",
       "sv8wkg"
@@ -22,7 +23,8 @@
             20.0,
             6.0
           ]
-        }
+        },
+        "$comment": "Local AABB in meters in the declared frame."
       },
       {
         "type": "bbox",
@@ -32,7 +34,8 @@
           35.2965,
           25.1665,
           35.3002
-        ]
+        ],
+        "$comment": "Earth-fixed bbox uses degrees [west,south,east,north]. If crossing 180°, west may be > east."
       }
     ]
   },
@@ -54,7 +57,8 @@
           0.2588,
           0.0
         ]
-      }
+      },
+      "$comment": "Pose maps FROM 'from' TO 'to'. q_wxyz follows GeoPose: [w,x,y,z], unit-norm. Use freshest transform with age ≤ valid_for_s."
     }
   ],
   "anchors": [

--- a/manifests/v1.3/content_experience_manifest.json
+++ b/manifests/v1.3/content_experience_manifest.json
@@ -22,6 +22,7 @@
     "local_tz": "America/New_York"
   },
   "coverage": {
+    "$comment": "If multiple coverage elements are present, they must bound the same resource. geohash (if used) is always earth-fixed.",
     "geohash": [
       "dr5ru9",
       "dr5rua"
@@ -36,7 +37,8 @@
           40.7793,
           -73.9631,
           40.7796
-        ]
+        ],
+        "$comment": "Earth-fixed bbox uses degrees [west,south,east,north]. If crossing 180°, west may be > east."
       },
       {
         "type": "volume",
@@ -52,7 +54,8 @@
             12.0,
             5.0
           ]
-        }
+        },
+        "$comment": "Local AABB in meters in the declared frame."
       }
     ]
   },
@@ -74,7 +77,8 @@
           0.3827,
           0.0
         ]
-      }
+      },
+      "$comment": "Pose maps FROM 'from' TO 'to'. q_wxyz follows GeoPose: [w,x,y,z], unit-norm. Use freshest transform with age ≤ valid_for_s."
     }
   ],
   "entrypoints": {

--- a/manifests/v1.3/mapping_service_manifest.json
+++ b/manifests/v1.3/mapping_service_manifest.json
@@ -25,6 +25,7 @@
     18
   ],
   "coverage": {
+    "$comment": "If multiple coverage elements are present, they must bound the same resource. geohash (if used) is always earth-fixed.",
     "geohash": [
       "9q8y",
       "9q8z"
@@ -39,7 +40,8 @@
           37.7925,
           -122.4115,
           37.799
-        ]
+        ],
+        "$comment": "Earth-fixed bbox uses degrees [west,south,east,north]. If crossing 180°, west may be > east."
       },
       {
         "type": "volume",
@@ -55,7 +57,8 @@
             37.799,
             250.0
           ]
-        }
+        },
+        "$comment": "Local AABB in meters in the declared frame."
       }
     ]
   },

--- a/manifests/v1.3/vps_manifest.json
+++ b/manifests/v1.3/vps_manifest.json
@@ -23,6 +23,7 @@
     "issuer": "https://auth.acme.com"
   },
   "coverage": {
+    "$comment": "If multiple coverage elements are present, they must bound the same resource. geohash (if used) is always earth-fixed.",
     "geohash": [
       "9q8y",
       "9q8z"
@@ -37,7 +38,8 @@
           37.7931,
           -122.4123,
           37.7982
-        ]
+        ],
+        "$comment": "Earth-fixed bbox uses degrees [west,south,east,north]. If crossing 180°, west may be > east."
       },
       {
         "type": "volume",
@@ -53,7 +55,8 @@
             30.0,
             20.0
           ]
-        }
+        },
+        "$comment": "Local AABB in meters in the declared frame."
       }
     ]
   },
@@ -75,7 +78,8 @@
           0.3827,
           0.0
         ]
-      }
+      },
+      "$comment": "Pose maps FROM 'from' TO 'to'. q_wxyz follows GeoPose: [w,x,y,z], unit-norm. Use freshest transform with age ≤ valid_for_s."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add clarifying $comment fields to v1.3 example manifests covering coverage elements and transforms
- update discovery IDL comments to capture GeoPose ordering and earth-fixed bbox expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5fe304e9c832c912ac1525ebed05f