### PR TITLE
Clarify HTTP discovery response description

### DIFF
--- a/SpatialDDS-1.3-full.md
+++ b/SpatialDDS-1.3-full.md
@@ -156,6 +156,8 @@ A matching response could be:
 ]
 ```
 
+This is the typical shape of an HTTP discovery response. Each entry corresponds to a `ContentAnnounce` object (the same structure used in the DDS binding), keeping resolver results and bus announcements aligned.
+
 The DDS binding mirrors this interaction with query and announce topics so edge deployments can keep discovery on the bus.
 
 ### **2.3 Anchors**

--- a/sections/v1.3/02-idl-profiles.md
+++ b/sections/v1.3/02-idl-profiles.md
@@ -52,6 +52,8 @@ A matching response could be:
 ]
 ```
 
+This is the typical shape of an HTTP discovery response. Each entry corresponds to a `ContentAnnounce` object (the same structure used in the DDS binding), keeping resolver results and bus announcements aligned.
+
 The DDS binding mirrors this interaction with query and announce topics, letting edge deployments deliver the same discovery experience without leaving the data bus.
 
 ### **2.3 Anchors**


### PR DESCRIPTION
## Summary
- clarify that HTTP resolver responses mirror the ContentAnnounce structure used on DDS
- note that aligned fields keep resolver results and bus announcements consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6215dc3f0832cb43ad9770d922609