### PR TITLE
Add ABNF appendix for SpatialDDS URIs

### DIFF
--- a/SpatialDDS-1.3-full.md
+++ b/SpatialDDS-1.3-full.md
@@ -32,6 +32,7 @@
     - [Appendix C: Anchor Registry Profile](sections/v1.3/appendix-c.md)
     - [Appendix D: Extension Profiles](sections/v1.3/appendix-d.md)
     - [Appendix E: Provisional Extension Examples](sections/v1.3/appendix-e.md)
+    - [Appendix F: SpatialDDS URI Scheme (ABNF)](sections/v1.3/appendix-f.md)
 
 ## **1\. Introduction**
 
@@ -1405,4 +1406,58 @@ agent::TaskStatus {
   stamp = { sec=1700000520, nsec=0 };
 }
 
+```
+
+## **Appendix F: SpatialDDS URI Scheme (ABNF)**
+
+SpatialDDS defines a URI scheme for anchors, content, and services. The human-readable pattern is:
+
+```text
+spatialdds://<authority>/<zone>/<rtype>/<rid>[;param][?query][#fragment]
+```
+
+- **authority** — a DNS name, case-insensitive.
+- **zone** — a namespace identifier (letters, digits, `-`, `_`, `:`).
+- **rtype** — resource type (for example `anchor`, `content`, `tileset`, `service`, `stream`).
+- **rid** — resource identifier (letters, digits, `-`, `_`).
+- **param** — optional `key=value` parameters separated by `;`.
+- **query/fragment** — follow RFC 3986 semantics.
+
+### **ABNF**
+
+The grammar below reuses RFC 3986 terminals (`ALPHA`, `DIGIT`, `unreserved`, `pct-encoded`, `query`, `fragment`).
+
+```abnf
+spatialdds-URI = "spatialdds://" authority "/" zone "/" rtype "/" rid
+                 *( ";" param ) [ "?" query ] [ "#" fragment ]
+
+authority      = dns-name
+dns-name       = label *( "." label )
+label          = alnum [ *( alnum / "-" ) alnum ]
+alnum          = ALPHA / DIGIT
+
+zone           = 1*( zone-char )
+zone-char      = ALPHA / DIGIT / "-" / "_" / ":"
+
+rtype          = "anchor" / "content" / "tileset" / "service" / "stream"
+
+rid            = 1*( rid-char )
+rid-char       = ALPHA / DIGIT / "-" / "_"
+
+param          = pname [ "=" pvalue ]
+pname          = 1*( ALPHA / DIGIT / "-" / "_" )
+pvalue         = 1*( unreserved / pct-encoded / ":" / "@" / "." )
+```
+
+### **Notes**
+
+- **Comparison rules**: authority is case-insensitive; all other components are case-sensitive after percent-decoding.
+- **Reserved params**: `v` (revision identifier), `ts` (RFC 3339 timestamp). Others are vendor-specific.
+- **Semantics**: URIs without `;v=` act as persistent identifiers (PID). With `;v=` they denote immutable revisions (RID).
+
+### **Examples**
+
+```text
+spatialdds://museum.example.org/hall1/anchor/01J9Q0A6KZ;v=12
+spatialdds://openarcloud.org/zone:sf/tileset/city3d;v=3?lang=en
 ```

--- a/SpatialDDS-1.3.md
+++ b/SpatialDDS-1.3.md
@@ -32,3 +32,4 @@
     - [Appendix C: Anchor Registry Profile](sections/v1.3/appendix-c.md)
     - [Appendix D: Extension Profiles](sections/v1.3/appendix-d.md)
     - [Appendix E: Provisional Extension Examples](sections/v1.3/appendix-e.md)
+    - [Appendix F: SpatialDDS URI Scheme (ABNF)](sections/v1.3/appendix-f.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - Appendix C: v1.3/appendix-c.md
       - Appendix D: v1.3/appendix-d.md
       - Appendix E: v1.3/appendix-e.md
+      - Appendix F: v1.3/appendix-f.md
       - Conclusion: v1.3/conclusion.md
       - Future Directions: v1.3/future-directions.md
       - Glossary: v1.3/glossary.md

--- a/sections/v1.3/02a-spatialdds-uris.md
+++ b/sections/v1.3/02a-spatialdds-uris.md
@@ -15,6 +15,8 @@ Every SpatialDDS URI names four ideas:
 
 The exact tokens and encoding rules are defined by the individual profiles, but at a glance the URIs read like `spatialdds://authority/zone/type/id;v=version`. Readers only need to recognize which part expresses ownership, scope, semantics, and revision so they can reason about the rest of the system.
 
+Formal syntax is given in Appendix F.
+
 ### 6.3 Working with SpatialDDS URIs
 
 Once a URI is known, clients ask the authority for the manifest it points to—typically via HTTPS, though authorities can advertise other transports if they operate private caches or field buses. The manifest reveals everything the client needs to act: anchor poses, dependency graphs for experiences, or how to reach a service. Because URIs remain lightweight, they are easy to pass around in tickets, QR codes, or discovery topics while deferring the heavier data fetch until runtime.

--- a/sections/v1.3/appendix-f.md
+++ b/sections/v1.3/appendix-f.md
@@ -1,0 +1,53 @@
+## **Appendix F: SpatialDDS URI Scheme (ABNF)**
+
+SpatialDDS defines a URI scheme for anchors, content, and services. The human-readable pattern is:
+
+```text
+spatialdds://<authority>/<zone>/<rtype>/<rid>[;param][?query][#fragment]
+```
+
+- **authority** — a DNS name, case-insensitive.
+- **zone** — a namespace identifier (letters, digits, `-`, `_`, `:`).
+- **rtype** — resource type (for example `anchor`, `content`, `tileset`, `service`, `stream`).
+- **rid** — resource identifier (letters, digits, `-`, `_`).
+- **param** — optional `key=value` parameters separated by `;`.
+- **query/fragment** — follow RFC 3986 semantics.
+
+### **ABNF**
+
+The grammar below reuses RFC 3986 terminals (`ALPHA`, `DIGIT`, `unreserved`, `pct-encoded`, `query`, `fragment`).
+
+```abnf
+spatialdds-URI = "spatialdds://" authority "/" zone "/" rtype "/" rid
+                 *( ";" param ) [ "?" query ] [ "#" fragment ]
+
+authority      = dns-name
+dns-name       = label *( "." label )
+label          = alnum [ *( alnum / "-" ) alnum ]
+alnum          = ALPHA / DIGIT
+
+zone           = 1*( zone-char )
+zone-char      = ALPHA / DIGIT / "-" / "_" / ":"
+
+rtype          = "anchor" / "content" / "tileset" / "service" / "stream"
+
+rid            = 1*( rid-char )
+rid-char       = ALPHA / DIGIT / "-" / "_"
+
+param          = pname [ "=" pvalue ]
+pname          = 1*( ALPHA / DIGIT / "-" / "_" )
+pvalue         = 1*( unreserved / pct-encoded / ":" / "@" / "." )
+```
+
+### **Notes**
+
+- **Comparison rules**: authority is case-insensitive; all other components are case-sensitive after percent-decoding.
+- **Reserved params**: `v` (revision identifier), `ts` (RFC 3339 timestamp). Others are vendor-specific.
+- **Semantics**: URIs without `;v=` act as persistent identifiers (PID). With `;v=` they denote immutable revisions (RID).
+
+### **Examples**
+
+```text
+spatialdds://museum.example.org/hall1/anchor/01J9Q0A6KZ;v=12
+spatialdds://openarcloud.org/zone:sf/tileset/city3d;v=3?lang=en
+```


### PR DESCRIPTION
## Summary
- add Appendix F documenting the SpatialDDS URI scheme and ABNF grammar
- reference the new appendix from the SpatialDDS URI section, table of contents, and MkDocs navigation

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d6a02e5ef8832c92dbf827bfe7d76a