### PR TITLE
Clarify appendix navigation labels

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,23 +16,23 @@ nav:
       - 7. Example Manifests: v1.3/03-example-manifests.md
       - 8. Glossary of Acronyms: v1.3/glossary.md
       - 9. References: v1.3/references.md
-      - Appendix A: v1.3/appendix-a.md
-      - Appendix B: v1.3/appendix-b.md
-      - Appendix C: v1.3/appendix-c.md
-      - Appendix D: v1.3/appendix-d.md
-      - Appendix E: v1.3/appendix-e.md
-      - Appendix F: v1.3/appendix-f.md
+      - Appendix A - Core Profile: v1.3/appendix-a.md
+      - Appendix B - Discovery Profile: v1.3/appendix-b.md
+      - Appendix C - Anchor Registry Profile: v1.3/appendix-c.md
+      - Appendix D - Extension Profiles: v1.3/appendix-d.md
+      - Appendix E - Provisional Extension Examples: v1.3/appendix-e.md
+      - Appendix F - SpatialDDS URI Scheme (ABNF): v1.3/appendix-f.md
       - Full Spec (single page): SpatialDDS-1.3-full.md
   - SpatialDDS 1.2:
       - 1. Introduction: v1.2/01-introduction.md
       - 2. IDL Profiles: v1.2/02-idl-profiles.md
       - 3. Example Manifests: v1.2/03-example-manifests.md
       - 4. Operational Scenarios: v1.2/04-operational-scenarios.md
-      - Appendix A: v1.2/appendix-a.md
-      - Appendix B: v1.2/appendix-b.md
-      - Appendix C: v1.2/appendix-c.md
-      - Appendix D: v1.2/appendix-d.md
-      - Appendix E: v1.2/appendix-e.md
+      - Appendix A - Core Profile: v1.2/appendix-a.md
+      - Appendix B - Discovery Profile: v1.2/appendix-b.md
+      - Appendix C - Anchor Registry Profile: v1.2/appendix-c.md
+      - Appendix D - Extension Profiles: v1.2/appendix-d.md
+      - Appendix E - Provisional Extension Examples: v1.2/appendix-e.md
       - Conclusion: v1.2/conclusion.md
       - Future Directions: v1.2/future-directions.md
       - Glossary: v1.2/glossary.md


### PR DESCRIPTION
## Summary
- update the MkDocs navigation entries for both specs so appendix links display labels such as "Appendix A - Core Profile"

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68d6ba43436c832cb153c6af1e8ac14a