### PR TITLE
Add editorial clarifications to SpatialDDS 1.4 spec

### DIFF
--- a/SpatialDDS-1.4-full.md
+++ b/SpatialDDS-1.4-full.md
@@ -105,6 +105,30 @@ This foundation ensures that SpatialDDS is not just a message format, but a full
 
 Before diving into identifiers and manifests, it helps to see how SpatialDDS components interlock when a client joins the bus. The typical flow looks like:
 
+### High-level layering
+
+SpatialDDS follows the same four-layer model shown in the architecture diagrams:
+
+Applications
+    ↓ use
+SpatialDDS Profiles
+    ↓ define
+DDS Topics (typed + QoS)
+    ↓ are described by
+Discovery & Manifests
+    ↓ reference
+spatial:// URIs
+
+- Applications (AR, robotics, digital twins, telco sensing, AI runtimes) use
+  SpatialDDS profiles instead of raw DDS topics.
+- Profiles define the shared types, semantics, and QoS groupings.
+- DDS topics carry typed streams with well-known QoS names.
+- Discovery and manifests describe the available streams and their spatial
+  coverage.
+- URIs provide stable identifiers for anchors, maps, content, and services.
+
+This textual view matches the layered diagrams used in the presentation.
+
 ```
 SpatialDDS URI ──▶ Manifest Resolver ──▶ Discovery Topic ──▶ DDS/Data Streams ──▶ Shared State & Anchors
         │                 │                      │                   │                      │
@@ -404,6 +428,19 @@ Consumers use these three keys to match and filter streams without inspecting pa
 - Earth-fixed frames (`fqn` rooted at `earth-fixed`) encode WGS84 longitude/latitude/height. Local frames MUST reference anchors or manifests that describe the transform back to an earth-fixed root (Appendix G).
 - Discovery announces and manifests share the same coverage semantics and flags. `CoverageQuery` responders SHALL apply these rules consistently when filtering or paginating results.
 - See §2 Conventions for global normative rules.
+
+### Earth-fixed roots and local frames
+
+For global interoperability, SpatialDDS assumes that earth-fixed frames
+(e.g., WGS84 longitude/latitude/height) form the root of the coverage
+hierarchy. Local frames (for devices, vehicles, buildings, or ships) may
+appear in coverage elements, but if the coverage is intended to be
+globally meaningful, these local frames must be relatable to an
+earth-fixed root through declared transforms or manifests.
+
+Implementations are not required to resolve every local frame at runtime,
+but when they do, the resulting coverage must be interpretable in an
+earth-fixed reference frame.
 
 #### Coverage Evaluation Pseudocode (Informative)
 ```
@@ -974,6 +1011,13 @@ module spatial {
 ## **Appendix B: Discovery Profile**
 
 *The Discovery profile defines the lightweight announce messages and manifests that allow services, coverage areas, and spatial content or experiences to be discovered at runtime. It enables SpatialDDS deployments to remain decentralized while still providing structured service discovery.*
+
+SpatialDDS Discovery is a bus-level mechanism: it describes nodes, topics,
+coverage, capabilities, and URIs that exist on the DDS fabric itself.
+Higher-level service catalogues (such as OSCP's Spatial Service Discovery
+Systems) are expected to run on top of SpatialDDS. They may store, index,
+or federate SpatialDDS manifests and URIs, but they are application-layer
+services and do not replace the on-bus discovery topics defined here.
 
 See **Appendix F.X (Discovery Query Expression)** for the normative grammar used by `CoverageQuery.expr` filters.
 

--- a/sections/v1.4/01-introduction.md
+++ b/sections/v1.4/01-introduction.md
@@ -63,6 +63,30 @@ This foundation ensures that SpatialDDS is not just a message format, but a full
 
 Before diving into identifiers and manifests, it helps to see how SpatialDDS components interlock when a client joins the bus. The typical flow looks like:
 
+### High-level layering
+
+SpatialDDS follows the same four-layer model shown in the architecture diagrams:
+
+Applications
+    ↓ use
+SpatialDDS Profiles
+    ↓ define
+DDS Topics (typed + QoS)
+    ↓ are described by
+Discovery & Manifests
+    ↓ reference
+spatial:// URIs
+
+- Applications (AR, robotics, digital twins, telco sensing, AI runtimes) use
+  SpatialDDS profiles instead of raw DDS topics.
+- Profiles define the shared types, semantics, and QoS groupings.
+- DDS topics carry typed streams with well-known QoS names.
+- Discovery and manifests describe the available streams and their spatial
+  coverage.
+- URIs provide stable identifiers for anchors, maps, content, and services.
+
+This textual view matches the layered diagrams used in the presentation.
+
 ```
 SpatialDDS URI ──▶ Manifest Resolver ──▶ Discovery Topic ──▶ DDS/Data Streams ──▶ Shared State & Anchors
         │                 │                      │                   │                      │

--- a/sections/v1.4/02-idl-profiles.md
+++ b/sections/v1.4/02-idl-profiles.md
@@ -208,6 +208,19 @@ Consumers use these three keys to match and filter streams without inspecting pa
 - Discovery announces and manifests share the same coverage semantics and flags. `CoverageQuery` responders SHALL apply these rules consistently when filtering or paginating results.
 - See §2 Conventions for global normative rules.
 
+### Earth-fixed roots and local frames
+
+For global interoperability, SpatialDDS assumes that earth-fixed frames
+(e.g., WGS84 longitude/latitude/height) form the root of the coverage
+hierarchy. Local frames (for devices, vehicles, buildings, or ships) may
+appear in coverage elements, but if the coverage is intended to be
+globally meaningful, these local frames must be relatable to an
+earth-fixed root through declared transforms or manifests.
+
+Implementations are not required to resolve every local frame at runtime,
+but when they do, the resulting coverage must be interpretable in an
+earth-fixed reference frame.
+
 #### Coverage Evaluation Pseudocode (Informative)
 ```
 if coverage.global:

--- a/sections/v1.4/appendix-b.md
+++ b/sections/v1.4/appendix-b.md
@@ -2,6 +2,13 @@
 
 *The Discovery profile defines the lightweight announce messages and manifests that allow services, coverage areas, and spatial content or experiences to be discovered at runtime. It enables SpatialDDS deployments to remain decentralized while still providing structured service discovery.*
 
+SpatialDDS Discovery is a bus-level mechanism: it describes nodes, topics,
+coverage, capabilities, and URIs that exist on the DDS fabric itself.
+Higher-level service catalogues (such as OSCP's Spatial Service Discovery
+Systems) are expected to run on top of SpatialDDS. They may store, index,
+or federate SpatialDDS manifests and URIs, but they are application-layer
+services and do not replace the on-bus discovery topics defined here.
+
 See **Appendix F.X (Discovery Query Expression)** for the normative grammar used by `CoverageQuery.expr` filters.
 
 ```idl


### PR DESCRIPTION
## Summary
- Add layered architecture text to match presentation diagrams
- Clarify that SpatialDDS Discovery is distinct from higher-level OSCP service discovery systems
- Highlight earth-fixed roots and local frame relationship in the coverage model

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ba44d5b8c832cb0bbb3c44f670531)